### PR TITLE
Fixes for missing parameters in SMS requests and responses

### DIFF
--- a/smsapi/actions/sms.py
+++ b/smsapi/actions/sms.py
@@ -54,7 +54,18 @@ class SendAction(ApiSendAction, ApiAction):
                         
         return self
                                                   
-    def set_date_validate(self, date_validate=True):   
+    def set_test(self, test=True):
+        if not test:
+            try:
+                del self._data['test']
+            except KeyError:
+                pass
+        else:
+            self._data['test'] = 1
+
+        return self
+
+    def set_date_validate(self, date_validate=True):
         if not date_validate:   
             try: 
                 del self._data['date_validate']

--- a/smsapi/responses.py
+++ b/smsapi/responses.py
@@ -43,7 +43,11 @@ class ApiResponse(object):
                 raise ApiError(data)
 
             self.count = data.get('count')
-            
+            # fields received for details=1
+            self.message = data.get('message')
+            self.length = data.get('length')
+            self.parts = data.get('parts')
+
             if 'list' in data:
                 self.data = data.get('list')
             else:


### PR DESCRIPTION
Before change sending test SMS without hacks like below was impossible.

```
api = SmsAPI()
api.service('sms').action('send')
api._action._data['test'] = 1
```

Also some data retrieved from https://api.smsapi.pl/sms.do with `details=1` was lost (`message`, `length` and `parts`).