### PR TITLE
Add fields missing from response when details=1

### DIFF
--- a/smsapi/responses.py
+++ b/smsapi/responses.py
@@ -43,7 +43,11 @@ class ApiResponse(object):
                 raise ApiError(data)
 
             self.count = data.get('count')
-            
+            # fields received for details=1
+            self.message = data.get('message')
+            self.length = data.get('length')
+            self.parts = data.get('parts')
+
             if 'list' in data:
                 self.data = data.get('list')
             else:


### PR DESCRIPTION
Title should be self-explanatory. Also take a look at my previous pull request: https://github.com/smsapi/smsapi-python-client/pull/13.