### PR TITLE
fix unhashable type caused by SmsApiException

### DIFF
--- a/smsapi/exception.py
+++ b/smsapi/exception.py
@@ -21,6 +21,9 @@ class SmsApiException(Exception):
     def __eq__(self, other):
         return other and self.__dict__ == other.__dict__
 
+    def __hash__(self):
+        return hash((self.message, self.code))
+
     def __repr__(self):
         return "<%s %s>" % (self.__class__.__name__, self.__dict__)
 


### PR DESCRIPTION
If you override custom `__eq__` method, you need to provide `__hash__` as well.
If not provided, raven crashes when handling the exception with:
TypeError: unhashable type: 'SmsApiException'
Minimal reproducible example:
```python
>>> from smsapi.exception import SmsApiException
>>> try:
...     raise SmsApiException("emplocity")
... except SmsApiException as e:
...     print(hash(e))
... 
```
