### PR TITLE
make SMSAPI  exceptions pickleable

### DIFF
--- a/smsapi/exception.py
+++ b/smsapi/exception.py
@@ -6,7 +6,7 @@ from smsapi.models import InvalidNumber
 class SmsApiException(Exception):
 
     def __init__(self, message, code=None, *args):
-        super(SmsApiException, self).__init__(*args)
+        super(SmsApiException, self).__init__(message, code, *args)
 
         self.message = message
         self.code = code

--- a/tests/unit/exceptions_test.py
+++ b/tests/unit/exceptions_test.py
@@ -1,0 +1,37 @@
+import pickle
+import unittest
+
+from smsapi.exception import (
+    ClientException,
+    EndpointException,
+    SendException,
+    SmsApiException,
+)
+
+
+class ExceptionPicklingTest(unittest.TestCase):
+    """Ensure SMS API custom exceptions are pickleable."""
+
+    def test_exception_pickling(self):
+        """Ensure SMS API exceptions are pickleable."""
+        message = 'test exception pickling'
+        exceptions = [
+            ClientException(message),
+            EndpointException(message),
+            SendException(message, code='pickiling_error'),
+            SmsApiException(message),
+        ]
+        for exception in exceptions:
+            with self.subTest(exception=exception):
+                self.assert_is_pickleable(exception)
+
+    def assert_is_pickleable(self, exception):
+        """Assert exception is pickleable."""
+        pickled_exception = pickle.dumps(exception)
+        self.assertEqual(pickle.loads(pickled_exception), exception)
+
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(ExceptionPicklingTest))
+    return suite

--- a/tests/unit/exceptions_test.py
+++ b/tests/unit/exceptions_test.py
@@ -12,18 +12,25 @@ from smsapi.exception import (
 class ExceptionPicklingTest(unittest.TestCase):
     """Ensure SMS API custom exceptions are pickleable."""
 
-    def test_exception_pickling(self):
-        """Ensure SMS API exceptions are pickleable."""
-        message = 'test exception pickling'
-        exceptions = [
-            ClientException(message),
-            EndpointException(message),
-            SendException(message, code='pickiling_error'),
-            SmsApiException(message),
-        ]
-        for exception in exceptions:
-            with self.subTest(exception=exception):
-                self.assert_is_pickleable(exception)
+    message = 'test exception pickling'
+
+    def test_client_exception_pickling(self):
+        """Ensure ``ClientException`` is pickleable."""
+        self.assert_is_pickleable(ClientException(self.message))
+
+    def test_endpoint_exception_pickling(self):
+        """Ensure ``EndpointException`` is pickleable."""
+        self.assert_is_pickleable(EndpointException(self.message))
+
+    def test_send_exception_pickling(self):
+        """Ensure ``SendException`` is pickleable."""
+        self.assert_is_pickleable(
+            SendException(self.message, code='pickling_error'),
+        )
+
+    def test_smsapi_exception_pickling(self):
+        """Ensure ``SmsApiException`` is pickleable."""
+        self.assert_is_pickleable(SmsApiException(self.message))
 
     def assert_is_pickleable(self, exception):
         """Assert exception is pickleable."""


### PR DESCRIPTION
Hi :wave: 

First of all thanks for the great API and its python client! 
Recently, I have started using [`celery`](https://github.com/celery/celery) to send SMS messages via SMSAPI and I discovered that it's impossible to store information about SMSAPI exceptions using celery result backends because SMSAPI exceptions are not pickleable.

In this PR I have added tests for SMSAPI exceptions pickling and made SMSAPI exceptions [pickleable](https://docs.celeryproject.org/en/stable/userguide/tasks.html#creating-pickleable-exceptions).